### PR TITLE
Sub: match velocity target override signature

### DIFF
--- a/ArduSub/Sub.cpp
+++ b/ArduSub/Sub.cpp
@@ -425,7 +425,7 @@ bool Sub::set_target_location(const Location& target_loc)
 #endif // AP_SCRIPTING_ENABLED || AP_EXTERNAL_CONTROL_ENABLED
 
 #if AP_SCRIPTING_ENABLED
-bool Sub::set_target_velocity_NED(const Vector3f& vel_ned)
+bool Sub::set_target_velocity_NED(const Vector3f& vel_ned, bool)
 {
     // exit if vehicle is not in Guided mode or Auto-Guided mode
     if (!flightmode->in_guided_mode()) {

--- a/ArduSub/Sub.h
+++ b/ArduSub/Sub.h
@@ -590,7 +590,7 @@ private:
 
 #if AP_SCRIPTING_ENABLED
     // guided velocity target for scripting (NED m/s)
-    bool set_target_velocity_NED(const Vector3f& vel_ned) override;
+    bool set_target_velocity_NED(const Vector3f& vel_ned, bool align_yaw_to_target) override;
 
     // guided position/velocity/attitude targets for scripting
     bool set_target_pos_NED(const Vector3f& target_pos, bool use_yaw, float yaw_deg, bool use_yaw_rate, float yaw_rate_degs, bool yaw_relative, bool terrain_alt) override;


### PR DESCRIPTION
### Summary

Update ArduSub's `set_target_velocity_NED` declaration and definition to accept the `align_yaw_to_target` argument introduced on the `AP_Vehicle` virtual method.

### Root cause

The fork's current `master` contains the updated two-argument `AP_Vehicle` method but retains ArduSub's older one-argument override. Boards that enable scripting fail while compiling generated Lua bindings because the ArduSub method no longer overrides the parent method.

This base-branch failure currently prevents the `test size` comparison jobs in #25 from completing.

### Testing

- `./waf configure --board sitl --no-submodule-update`
- `./waf sub`
- Confirmed the isolated patch is identical to the fix validated by that successful ArduSub SITL build.
- `git diff --check`

This contribution was AI-assisted. Codex traced the GitHub Actions failures, isolated the existing two-line compatibility fix onto the current `master`, and performed the validation described above.