### PR TITLE
Tools: publish ArduSub bin firmware artifacts

### DIFF
--- a/.github/workflows/sunfish_ci.yml
+++ b/.github/workflows/sunfish_ci.yml
@@ -55,10 +55,8 @@ jobs:
              "release-assets/${{ matrix.board }}-ardusub.apj"
           cp "build/${{ matrix.board }}/bin/ardusub_with_bl.hex" \
              "release-assets/${{ matrix.board }}-ardusub-with-bootloader.hex"
-          if [ -f "build/${{ matrix.board }}/bin/ardusub.abin" ]; then
-            cp "build/${{ matrix.board }}/bin/ardusub.abin" \
-               "release-assets/${{ matrix.board }}-ardusub.abin"
-          fi
+          cp "build/${{ matrix.board }}/bin/ardusub.bin" \
+             "release-assets/${{ matrix.board }}-ardusub.bin"
       - name: Archive firmware artifacts
         uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
### Summary

Publish standard `.bin` ArduSub firmware artifacts for each CUAV board in the Sunfish CI matrix instead of the optional `.abin` artifact.

### Classification & Testing

- [ ] Checked by a human programmer
- [x] Non-functional change
- [x] No-binary change
- [x] Infrastructure change (workflow)
- [ ] Automated test(s) verify changes
- [x] Tested manually: workflow YAML parsed successfully and `git diff --check` passed
- [ ] Tested on hardware
- [ ] Logs attached
- [ ] Logs available on request

### Description

The ChibiOS build generates `ardusub.bin` for both CUAV-7-Nano and CUAVv5Nano. The workflow now publishes it as `${{ matrix.board }}-ardusub.bin` for each board, replacing the previous conditional `.abin` copy.

This contribution was prepared with AI assistance; the human author remains responsible for reviewing and validating the change.